### PR TITLE
Prod

### DIFF
--- a/Instructions/CloudLabs.AI/LAB_06-Implement_Network_Traffic_Management.md
+++ b/Instructions/CloudLabs.AI/LAB_06-Implement_Network_Traffic_Management.md
@@ -373,7 +373,7 @@ In this task, you will configure and test routing between the two spoke virtual 
     | Source type | **Virtual machine** |
     | Virtual machine | **az104-06-vm2** |
     | Destination | **Specify manually** |
-    | URI, FQDN or IPv4 | **10.62.0.4** |
+    | URI, FQDN or IPv4 | **10.63.0.4** |
     | Protocol | **TCP** |
     | Destination Port | **3389** |
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 00

Fixes # .

The traffic flow check after enabling the traffic forwarding from 10.62.0.0/24 network to 10.63.0.0/24 via 10.60.0.0/24 should be done between 10.62.0.4 and 10.63.0.4.

Lab guide currently shows verify flow from az104-06-vm2 and 10.62.0.4 which refers to the same vm. Updated the value to 10.63.0.4

Changes proposed in this pull request:

https://github.com/chakra146/AZ-104-MicrosoftAzureAdministrator/blob/prod/Instructions/media/lab06.png

![image](https://user-images.githubusercontent.com/61271207/207377552-14cb65e7-0a0f-49f8-9dc4-b58fb1b7b7e5.png)
